### PR TITLE
Make naming consistent (Anomaly -> Monitor, and others)

### DIFF
--- a/uptrain/core/classes/managers/check_manager.py
+++ b/uptrain/core/classes/managers/check_manager.py
@@ -21,28 +21,28 @@ from uptrain.core.classes.visuals import Umap, Tsne, Shap
 
 class CheckManager:
     def __init__(self, framework, checks=[]):
-        self.anomalies_to_check = []
+        self.monitors_to_check = []
         self.statistics_to_check = []
         self.visuals_to_check = []
         self.fw = framework
         for check in checks:
             if check["type"] in Monitor:
-                self.add_anomaly_to_monitor(check)
+                self.add_monitor(check)
             if check["type"] in Statistic:
-                self.add_statistics_to_monitor(check)
+                self.add_statistic(check)
             if check["type"] in Visual:
-                self.add_visuals(check)
+                self.add_visual(check)
 
-    def add_anomaly_to_monitor(self, check):
+    def add_monitor(self, check):
         if check["type"] == Monitor.EDGE_CASE:
             edge_case_manager = EdgeCase(self.fw, check)
-            self.anomalies_to_check.append(edge_case_manager)
+            self.monitors_to_check.append(edge_case_manager)
         elif check["type"] == Monitor.ACCURACY:
             acc_manager = Accuracy(self.fw, check)
-            self.anomalies_to_check.append(acc_manager)
+            self.monitors_to_check.append(acc_manager)
         elif check["type"] == Monitor.CONCEPT_DRIFT:
             drift_manager = ConceptDrift(self.fw, check)
-            self.anomalies_to_check.append(drift_manager)
+            self.monitors_to_check.append(drift_manager)
         elif check["type"] == Monitor.DATA_DRIFT:
             if "measurable_args" in check:
                 drift_managers = [DataDrift(self.fw, check)]
@@ -60,20 +60,20 @@ class CheckManager:
                         }
                     )
                     drift_managers.append(DataDrift(self.fw,check_copy))
-            self.anomalies_to_check.extend(drift_managers)
+            self.monitors_to_check.extend(drift_managers)
         elif check["type"] == Monitor.POPULARITY_BIAS:
             bias_manager = ModelBias(self.fw, check)
-            self.anomalies_to_check.append(bias_manager)
+            self.monitors_to_check.append(bias_manager)
         elif check["type"] == Monitor.CUSTOM_MONITOR:
             custom_monitor = CustomMonitor(self.fw, check)
-            self.anomalies_to_check.append(custom_monitor)
+            self.monitors_to_check.append(custom_monitor)
         elif check["type"] == Monitor.DATA_INTEGRITY:
             custom_monitor = DataIntegrity(self.fw, check)
-            self.anomalies_to_check.append(custom_monitor)
+            self.monitors_to_check.append(custom_monitor)
         else:
             raise Exception("Monitor type not Supported")
 
-    def add_statistics_to_monitor(self, check):
+    def add_statistic(self, check):
         if check["type"] == Statistic.DISTANCE:
             custom_monitor = Distance(self.fw, check)
             self.statistics_to_check.append(custom_monitor)
@@ -86,7 +86,7 @@ class CheckManager:
         else:
             raise Exception("Statistic type not Supported")
 
-    def add_visuals(self, check):
+    def add_visual(self, check):
         if check["type"] == Visual.UMAP:
             custom_monitor = Umap(self.fw, check)
             self.visuals_to_check.append(custom_monitor)
@@ -100,9 +100,9 @@ class CheckManager:
             raise Exception("Visual type not Supported")
 
     def check(self, inputs, outputs, gts=None, extra_args={}):
-        for anomaly in self.anomalies_to_check:
-            if anomaly.need_ground_truth() == (gts[0] is not None):
-                anomaly.check(inputs, outputs, gts=gts, extra_args=extra_args)
+        for monitor in self.monitors_to_check:
+            if monitor.need_ground_truth() == (gts[0] is not None):
+                monitor.check(inputs, outputs, gts=gts, extra_args=extra_args)
         for stats in self.statistics_to_check:
             stats.check(inputs, outputs, gts=gts, extra_args=extra_args)
         for visuals in self.visuals_to_check:
@@ -111,9 +111,9 @@ class CheckManager:
     def is_data_interesting(self, inputs, outputs, gts=None, extra_args={}):
         is_interesting = []
         reasons = []
-        for anomaly in self.anomalies_to_check:
-            if anomaly.need_ground_truth() == (gts[0] is not None):
-                res = anomaly.is_data_interesting(
+        for monitor in self.monitors_to_check:
+            if monitor.need_ground_truth() == (gts[0] is not None):
+                res = monitor.is_data_interesting(
                         inputs, outputs, gts=gts, extra_args=extra_args
                     )
                 is_interesting.append(res[0])

--- a/uptrain/core/classes/monitors/abstract_monitor.py
+++ b/uptrain/core/classes/monitors/abstract_monitor.py
@@ -3,7 +3,7 @@ import numpy as np
 from uptrain.core.classes.monitors import AbstractCheck
 
 class AbstractMonitor(AbstractCheck):
-    anomaly_type = None
+    monitor_type = None
 
     def need_ground_truth(self):
         return False

--- a/uptrain/core/classes/monitors/accuracy.py
+++ b/uptrain/core/classes/monitors/accuracy.py
@@ -8,6 +8,7 @@ from uptrain.constants import Monitor
 class Accuracy(AbstractMonitor):
     dashboard_name = "accuracy"
     monitor_type = Monitor.ACCURACY
+    
     def base_init(self, fw, check):
         if check.get("measurable_args", None):
             self.measurable = MeasurableResolver(check["measurable_args"]).resolve(fw)

--- a/uptrain/core/classes/monitors/concept_drift.py
+++ b/uptrain/core/classes/monitors/concept_drift.py
@@ -9,7 +9,7 @@ from uptrain.constants import Monitor
 
 class ConceptDrift(AbstractMonitor):
     dashboard_name = "concept_drift_acc"
-    anomaly_type = Monitor.CONCEPT_DRIFT
+    monitor_type = Monitor.CONCEPT_DRIFT
 
     def base_init(self, fw, check):
         if check.get("measurable_args", None):

--- a/uptrain/core/classes/monitors/custom_monitor.py
+++ b/uptrain/core/classes/monitors/custom_monitor.py
@@ -4,7 +4,7 @@ from uptrain.constants import Monitor
 
 
 class CustomMonitor(AbstractMonitor):
-    anomaly_type = Monitor.CUSTOM_MONITOR
+    monitor_type = Monitor.CUSTOM_MONITOR
 
     def base_init(self, fw, check):
         self.dashboard_name = check.get("dashboard_name", "custom_measure")

--- a/uptrain/core/classes/monitors/data_drift.py
+++ b/uptrain/core/classes/monitors/data_drift.py
@@ -10,7 +10,7 @@ from uptrain.core.classes.algorithms import Clustering
 
 class DataDrift(AbstractMonitor):
     dashboard_name = "data_drift"
-    anomaly_type = Monitor.DATA_DRIFT
+    monitor_type = Monitor.DATA_DRIFT
     is_embedding = None
     mode = None
     NUM_BUCKETS = 20

--- a/uptrain/core/classes/monitors/data_integrity.py
+++ b/uptrain/core/classes/monitors/data_integrity.py
@@ -7,7 +7,7 @@ from uptrain.constants import Monitor
 
 class DataIntegrity(AbstractMonitor):
     dashboard_name = "data_integrity"
-    anomaly_type = Monitor.DATA_INTEGRITY
+    monitor_type = Monitor.DATA_INTEGRITY
 
     def base_init(self, fw, check):
         self.integrity_type = check["integrity_type"]

--- a/uptrain/core/classes/monitors/edge_case.py
+++ b/uptrain/core/classes/monitors/edge_case.py
@@ -7,7 +7,7 @@ from uptrain.constants import Monitor
 
 class EdgeCase(AbstractMonitor):
     dashboard_name = "edge_cases"
-    anomaly_type = Monitor.EDGE_CASE
+    monitor_type = Monitor.EDGE_CASE
 
     def base_init(self, fw, check):
         self.signal_manager = SignalManager()

--- a/uptrain/core/classes/monitors/model_bias.py
+++ b/uptrain/core/classes/monitors/model_bias.py
@@ -7,7 +7,7 @@ from uptrain.constants import BiasAlgo, Monitor
 
 class ModelBias(AbstractMonitor):
     dashboard_name = "popularity_bias"
-    anomaly_type = Monitor.POPULARITY_BIAS
+    monitor_type = Monitor.POPULARITY_BIAS
 
     def base_init(self, fw, check):
         self.acc_arr = []

--- a/uptrain/core/classes/statistics/convergence.py
+++ b/uptrain/core/classes/statistics/convergence.py
@@ -11,7 +11,7 @@ from uptrain.constants import Statistic
 
 class Convergence(AbstractStatistic):
     dashboard_name = "convergence_stats"
-    anomaly_type = Statistic.CONVERGENCE_STATS
+    statistic_type = Statistic.CONVERGENCE_STATS
 
     def base_init(self, fw, check):
         self.aggregate_measurable = MeasurableResolver(check["aggregate_args"]).resolve(

--- a/uptrain/core/classes/statistics/distance.py
+++ b/uptrain/core/classes/statistics/distance.py
@@ -9,7 +9,7 @@ from uptrain.constants import Statistic
 
 class Distance(AbstractStatistic):
     dashboard_name = "distance"
-    anomaly_type = Statistic.DISTANCE
+    statistic_type = Statistic.DISTANCE
 
     def base_init(self, fw, check):
         self.aggregate_measurable = MeasurableResolver(check["aggregate_args"]).resolve(

--- a/uptrain/core/classes/visuals/tsne.py
+++ b/uptrain/core/classes/visuals/tsne.py
@@ -147,7 +147,9 @@ class Tsne(AbstractVisual):
                     self.min_samples,
                     label_list=label_list
                 )
-                this_data = {"umap": tsne_list, "clusters": clusters, "hover_texts": hover_texts}
+                this_data = {"umap": tsne_list, "clusters": clusters}
+                if len(hover_texts) > 0:
+                    this_data.update({"hover_texts": hover_texts})
                 self.log_handler.add_histogram(
                     "tsne_and_clusters",
                     this_data,

--- a/uptrain/core/classes/visuals/umap.py
+++ b/uptrain/core/classes/visuals/umap.py
@@ -127,7 +127,9 @@ class Umap(AbstractVisual):
                     self.min_samples,
                     label_list=label_list
                 )
-                this_data = {"umap": umap_list, "clusters": clusters, "hover_texts": hover_texts}
+                this_data = {"umap": umap_list, "clusters": clusters}
+                if len(hover_texts) > 0:
+                    this_data.update({"hover_texts": hover_texts})
                 self.log_handler.add_histogram(
                     "umap_and_clusters",
                     this_data,


### PR DESCRIPTION
#109 changed class name from Anomaly to Monitor. However, not all files had the changes made consistently in #129. Some naming was also inconsistent between files. This PR adds onto the previous fix.