### PR TITLE
Add documentation and type hints to uptrain.core.classes.measurables

### DIFF
--- a/uptrain/core/classes/measurables/__init__.py
+++ b/uptrain/core/classes/measurables/__init__.py
@@ -9,5 +9,4 @@ from .accuracy import AccuracyMeasurable, MAEMeasurable, MAPEMeasurable
 from .scalar_from_embedding import ScalarFromEmbeddingMeasurable
 from .distance import DistanceMeasurable
 from .reccomendation_hit_rate import RecHitRateMeasurable
-
 from .measurable_resolver import MeasurableResolver

--- a/uptrain/core/classes/measurables/abstract.py
+++ b/uptrain/core/classes/measurables/abstract.py
@@ -1,9 +1,44 @@
 from abc import ABC
+from typing import Any
 
 
 class AbstractMeasurable(ABC):
+    """Abstract base class for objects that can be measured or evaluated.
+
+    This abstract class provides a template for defining objects that can
+    be evaluated in some way. Subclasses of  AbstractMeasurable should
+    implement the `_compute` method, which performs the actual computation.
+    """
+
     def __init__(self) -> None:
         super().__init__()
 
-    def _compute(self, inputs=None, outputs=None, gts=None, extra=None) -> any:
+    def _compute(self, inputs=None, outputs=None, gts=None, extra=None) -> Any:
+        """Computes the measurement or evaluation of this object.
+
+        This method should be overridden by subclasses to perform the actual
+        computation of the measurement or evaluation. The inputs, outputs and
+        gts parameters can be used in the computation. The extra parameter can
+        be used to provided additional information for the computation.
+
+        Parameters
+        ----------
+        inputs
+            Inputs values to use in the computation
+        outputs
+            Outputs values to use in the computation
+        gts
+            Ground truth values to use in the computation
+        extra
+            Additional information to use in the computation
+
+        Returns
+        -------
+        Any
+            Result of the computation
+        """
+        raise Exception("Should be defined for each individual class")
+
+    def col_name (self) -> str:
+        """Returns the column name of the Measurable"""
         raise Exception("Should be defined for each individual class")

--- a/uptrain/core/classes/measurables/accuracy.py
+++ b/uptrain/core/classes/measurables/accuracy.py
@@ -4,39 +4,59 @@ from uptrain.core.classes.measurables import Measurable
 
 
 class AccuracyMeasurable(Measurable):
+    """Class that computes the accuracy from predictions and ground truths.
+
+    Returns a list of values where a value is:
+    - True, if prediction equals ground truth
+    - False, if prediction does not equal ground truth
+    """
+
     def __init__(self, framework) -> None:
         super().__init__(framework)
 
-    def _compute(self, inputs=None, outputs=None, gts=None, extra=None) -> any:
+    def _compute(self, inputs=None, outputs=None, gts=None, extra=None) -> np.ndarray:
         gts = np.array(gts)
         outputs = np.reshape(np.array(outputs), gts.shape)
         return np.equal(outputs, gts)
 
-    def col_name(self):
-        return "Accuracy" 
+    def col_name(self) -> str:
+        return "Accuracy"
 
 
 class MAEMeasurable(Measurable):
+    """Class that computes the Mean Absolute Error from predictions and ground truths.
+
+    Returns a list of values where each value is the absolute value of the
+    difference between corresponding prediction and ground truth.
+    """
+
     def __init__(self, framework) -> None:
         super().__init__(framework)
 
-    def _compute(self, inputs=None, outputs=None, gts=None, extra=None) -> any:
+    def _compute(self, inputs=None, outputs=None, gts=None, extra=None) -> np.ndarray:
         gts = np.array(gts)
         outputs = np.reshape(np.array(outputs), gts.shape)
         return np.squeeze(np.abs(outputs - gts))
 
-    def col_name(self):
+    def col_name(self) -> str:
         return "MAE"
 
 
 class MAPEMeasurable(Measurable):
+    """Class that computes the Mean Absolute Percentage Error from predictions and ground truths.
+
+    Returns a list of values where each value is the absolute percentage
+    difference between corresponding prediction and ground truth,
+    multiplied by 100 to express the result as a percentage.
+    """
+    
     def __init__(self, framework) -> None:
         super().__init__(framework)
 
-    def _compute(self, inputs=None, outputs=None, gts=None, extra=None) -> any:
+    def _compute(self, inputs=None, outputs=None, gts=None, extra=None) -> np.ndarray:
         gts = np.array(gts)
         outputs = np.reshape(np.array(outputs), gts.shape)
-        return 100*np.squeeze(np.abs(np.divide(outputs - gts, gts)))
+        return 100 * np.squeeze(np.abs(np.divide(outputs - gts, gts)))
 
-    def col_name(self):
-        return "MAPE"    
+    def col_name(self) -> str:
+        return "MAPE"

--- a/uptrain/core/classes/measurables/condition.py
+++ b/uptrain/core/classes/measurables/condition.py
@@ -1,8 +1,35 @@
+from typing import Any, Dict
+
 from uptrain.core.classes.measurables import Measurable, FeatureMeasurable
 
 
 class ConditionMeasurable(Measurable):
-    def __init__(self, framework, underlying, condition) -> None:
+    """Class that computes a boolean condition on a measurable feature."""
+
+    def __init__(
+        self, framework, underlying: Dict[str, Any], condition: Dict[str, Any]
+    ) -> None:
+        """Constructor for ConditionMeasurable class.
+
+        Parameters
+        ----------
+        framework
+            UpTrain Framework object
+        underlying
+            A dictionary containing the feature_name to apply the condition on and
+            the dictn_type (whether to apply on inputs or outputs).
+            dictn_type should be "inputs" for applying InputFeatureMeasurable
+            dictn_type should be "outputs" for applying OutputFeatureMeasurable
+        condition
+            A dictionary containing either "formulae" or "func" as key.
+            If "formulae" is provided:
+                - it must be a boolean operator from the following list of operators:
+                    ["<", "<=", ">", ">=", "==", "le", "leq", "ge", "geq", "eq"]
+                - it must contain "threshold" as key which provides the value to perform
+                  the boolean condition against.
+            If "func" is provided, it should map to a callback that accepts a single
+            argument and returns a boolean value.
+        """
         super().__init__(framework)
         self.underlying = underlying
         self.condition = condition
@@ -37,10 +64,4 @@ class ConditionMeasurable(Measurable):
         )
 
     def col_name(self):
-        return (
-            "Condition("
-            + self.feature.col_name()
-            + ","
-            + str(self.condition)
-            + ")"
-        )
+        return f"Condition({self.feature.col_name()}, {str(self.condition)})"

--- a/uptrain/core/classes/measurables/condition.py
+++ b/uptrain/core/classes/measurables/condition.py
@@ -58,10 +58,10 @@ class ConditionMeasurable(Measurable):
             )
         self.condition_func = condition_func
 
-    def _compute(self, inputs=None, outputs=None, gts=None, extra=None) -> any:
+    def _compute(self, inputs=None, outputs=None, gts=None, extra=None) -> Any:
         return self.condition_func(
             self.feature._compute(inputs=inputs, outputs=outputs, gts=gts, extra=extra)
         )
 
-    def col_name(self):
+    def col_name(self) -> str:
         return f"Condition({self.feature.col_name()}, {str(self.condition)})"

--- a/uptrain/core/classes/measurables/custom.py
+++ b/uptrain/core/classes/measurables/custom.py
@@ -1,17 +1,33 @@
 import numpy as np
 
+from typing import Any, Dict
+
 from uptrain.core.classes.measurables import Measurable
 from uptrain.core.classes.signals import SignalManager
 
 
 class CustomMeasurable(Measurable):
-    def __init__(self, framework, custom_args={}) -> None:
+    """Class that computes a custom metric measurable using a user-defined signal formula."""
+
+    def __init__(self, framework, custom_args: Dict[str, Any] = {}) -> None:
+        """Constructor for CustomMeasurable class.
+
+        Parameters
+        ----------
+        framework
+            UpTrain framework object
+        custom_args
+            A dictionary containing custom arguments for usage in computation.
+            The dictionary must contain "signal_formulae" as key which maps to
+            a callback that takes in inputs, outputs, gts and extra_args, and
+            returns a boolean value as the signal measure.
+        """
         super().__init__(framework)
         self._args = custom_args
         self.signal_manager = SignalManager()
         self.signal_manager.add_signal_formulae(self._args["signal_formulae"])
 
-    def _compute(self, inputs=None, outputs=None, gts=None, extra=None) -> any:
+    def _compute(self, inputs=None, outputs=None, gts=None, extra=None) -> np.ndarray:
         val = self.signal_manager.evaluate_signal(
             inputs, outputs, gts=gts, extra_args=extra
         )

--- a/uptrain/core/classes/measurables/custom.py
+++ b/uptrain/core/classes/measurables/custom.py
@@ -33,7 +33,7 @@ class CustomMeasurable(Measurable):
         )
         return val
 
-    def col_name(self):
+    def col_name(self) -> str:
         return str(self.signal_manager)
 
     # TODO: Decommission and find a generic way

--- a/uptrain/core/classes/measurables/distance.py
+++ b/uptrain/core/classes/measurables/distance.py
@@ -1,4 +1,4 @@
-import numpy as np
+from typing import Any, List, Union
 
 from uptrain.core.classes.distances import DistanceResolver
 from uptrain.core.classes.measurables import Measurable
@@ -24,7 +24,7 @@ class DistanceMeasurable(Measurable):
             Distance types must be from the list:
                 ["cosine_distance", "l2_distance", "norm_ratio"]
         """
-        
+
         super().__init__(framework)
         self.base = InputFeatureMeasurable(framework, base["feature_name"])
         self.reference = reference
@@ -32,7 +32,7 @@ class DistanceMeasurable(Measurable):
         self.distance_types = distance_types
         self.dist_classes = [DistanceResolver().resolve(x) for x in self.distance_types]
 
-    def _compute(self, inputs=None, outputs=None, gts=None, extra=None) -> any:
+    def _compute(self, inputs=None, outputs=None, gts=None, extra=None) -> Any:
         base_val = self.base.compute_and_log(
             inputs=inputs, outputs=outputs, gts=gts, extra=extra
         )
@@ -50,7 +50,7 @@ class DistanceMeasurable(Measurable):
             self.ref_val = base_val
         return dists
 
-    def col_name(self, return_str=True):
+    def col_name(self, return_str: bool = True) -> Union[List[str], str]:
         col_names = [
             f"Distance {str(self.base.col_name())} {self.reference} {str(x)}"
             for x in self.distance_types

--- a/uptrain/core/classes/measurables/distance.py
+++ b/uptrain/core/classes/measurables/distance.py
@@ -6,7 +6,25 @@ from uptrain.core.classes.measurables import InputFeatureMeasurable
 
 
 class DistanceMeasurable(Measurable):
+    """Class that computes and logs distance based on chosen distance metric."""
+
     def __init__(self, framework, base, reference, distance_types) -> None:
+        """Constructor for DistanceMeasurable class.
+
+        Parameters
+        ----------
+        framework
+            UpTrain Framework object
+        base
+            TODO
+        reference
+            TODO
+        distance_types
+            The distance types to use for computation in the distance metric.
+            Distance types must be from the list:
+                ["cosine_distance", "l2_distance", "norm_ratio"]
+        """
+        
         super().__init__(framework)
         self.base = InputFeatureMeasurable(framework, base["feature_name"])
         self.reference = reference
@@ -34,10 +52,7 @@ class DistanceMeasurable(Measurable):
 
     def col_name(self, return_str=True):
         col_names = [
-            "Distance "
-            + str(self.base.col_name())
-            + self.reference
-            + str(x)
+            f"Distance {str(self.base.col_name())} {self.reference} {str(x)}"
             for x in self.distance_types
         ]
         if return_str:

--- a/uptrain/core/classes/measurables/feature.py
+++ b/uptrain/core/classes/measurables/feature.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from uptrain.core.classes.measurables import (
     Measurable,
     InputFeatureMeasurable,
@@ -6,7 +8,19 @@ from uptrain.core.classes.measurables import (
 
 
 class FeatureMeasurable(Measurable):
-    def __init__(self, framework, feature_name, dictn_type) -> None:
+    """Class that returns a feature as a result of computation."""
+
+    def __init__(self, framework, feature_name, dictn_type: str) -> None:
+        """Constructor for FeatureMeasurable class.
+        
+        Parameters
+        ----------
+        feature_name
+            Name of the feature that is to be measured/evaluated
+        dictn_type
+            Must be "inputs" or "outputs" depending on which feature to
+            measure/evaluate
+        """
         super().__init__(framework)
         self.feature_name = feature_name
         self.dictn_type = dictn_type
@@ -19,12 +33,12 @@ class FeatureMeasurable(Measurable):
                 "Helper Measurable not defined for dictionary type %s" % self.dictn_type
             )
 
-    def _compute(self, inputs=None, outputs=None, gts=None, extra=None) -> any:
+    def _compute(self, inputs=None, outputs=None, gts=None, extra=None) -> Any:
         return self.helper._compute(
             inputs=inputs, outputs=outputs, gts=gts, extra=extra
         )
 
-    def col_name(self):
+    def col_name(self) -> str:
         return self.helper.col_name()
 
     # TODO: Decommission and find a generic way

--- a/uptrain/core/classes/measurables/input_feature.py
+++ b/uptrain/core/classes/measurables/input_feature.py
@@ -1,18 +1,19 @@
-import numpy as np
+from typing import Any
 
 from uptrain.core.classes.measurables import Measurable
 
 
 class InputFeatureMeasurable(Measurable):
+    """Class that returns the input feature corresponding to the feature name."""
+
     def __init__(self, framework, feature_name) -> None:
         super().__init__(framework)
         self.feature_name = feature_name
 
-    def _compute(self, inputs=None, outputs=None, gts=None, extra=None) -> any:
-        val = inputs[self.feature_name]
-        return val
+    def _compute(self, inputs=None, outputs=None, gts=None, extra=None) -> Any:
+        return inputs[self.feature_name]
 
-    def col_name(self):
+    def col_name(self) -> str:
         return str(self.feature_name)
 
     # TODO: Decommission and find a generic way

--- a/uptrain/core/classes/measurables/measurable.py
+++ b/uptrain/core/classes/measurables/measurable.py
@@ -1,5 +1,7 @@
 import numpy as np
 
+from typing import Any
+
 from uptrain.core.lib.helper_funcs import (
     extract_data_points_from_batch,
     combine_data_points_for_batch,
@@ -8,12 +10,43 @@ from uptrain.core.classes.measurables import AbstractMeasurable
 
 
 class Measurable(AbstractMeasurable):
+    """Class that contains the core logic for computation/logging of a measurable.
+
+    This class is a subclass of AbstractMeasurable and implements the computation
+    and logging of a measurable or evaluatable object. It can optionally use a
+    cache to avoid recomputing values that have already been computed.
+    """
+
     def __init__(self, framework) -> None:
         super().__init__()
         self.framework = framework
         self.cache_present_or_not = None
 
-    def compute_and_log(self, inputs=None, outputs=None, gts=None, extra=None) -> None:
+    def compute_and_log(self, inputs=None, outputs=None, gts=None, extra=None) -> Any:
+        """Computes the measurement and logs the result.
+
+        This method computes the measurement of this object using the overriden
+        _compute method, and logs the result. If caching is enabled in the
+        UpTrain framework object, this method may use the cache to avoid recomputing
+        values that have already been computed.
+
+        Parameters
+        ----------
+        inputs
+            Inputs values to use in the computation
+        outputs
+            Outputs values to use in the computation
+        gts
+            Ground truth values to use in the computation
+        extra
+            Additional information to use in the computation
+
+        Returns
+        -------
+        Any
+            Result of the computation
+        """
+
         if self.framework.use_cache:
             if self.cache_present_or_not is None:
                 self.cache_present_or_not = 1
@@ -67,5 +100,18 @@ class Measurable(AbstractMeasurable):
             vals = self._compute(inputs=inputs, outputs=outputs, gts=gts, extra=extra)
         return vals
 
-    def _log(self, ids, vals) -> None:
+    def _log(self, ids: np.ndarray, vals: np.ndarray) -> None:
+        """Logs the result of the computation.
+
+        This method logs the result of the computation for the given ids and vals
+        using the log_measurable method of UpTrain framework object.
+
+        Parameters
+        ----------
+        ids
+            List of unique identifiers for inputs, which is used to match them with
+            their computed values in the framework's logging system
+        vals
+            List of computed measurable values for inputs
+        """
         self.framework.log_measurable(ids, vals, self.col_name())

--- a/uptrain/core/classes/measurables/measurable_resolver.py
+++ b/uptrain/core/classes/measurables/measurable_resolver.py
@@ -14,17 +14,17 @@ from uptrain.constants import MeasurableType
 
 
 class MeasurableResolver:
+    """Class that resolves a measurable key to a measurable class instance."""
+
     def __init__(self, args) -> None:
         super().__init__()
         self._args = args
 
-    def has_valid_resolve_args(self):
+    def has_valid_resolve_args(self) -> bool:
         if self._args is None:
             return False
-
         if len(self._args) == 0:
             return False
-
         return True
 
     def resolve(self, framework) -> Measurable:

--- a/uptrain/core/classes/measurables/output_feature.py
+++ b/uptrain/core/classes/measurables/output_feature.py
@@ -1,15 +1,19 @@
+from typing import Any
+
 from uptrain.core.classes.measurables import Measurable
 
 
 class OutputFeatureMeasurable(Measurable):
+    """Class that returns the output feature corresponding to the feature name."""
+
     def __init__(self, framework, feature_name) -> None:
         super().__init__(framework)
         self.feature_name = feature_name
 
-    def _compute(self, inputs=None, outputs=None, gts=None, extra=None) -> any:
+    def _compute(self, inputs=None, outputs=None, gts=None, extra=None) -> Any:
         return outputs
 
-    def col_name(self):
+    def col_name(self) -> str:
         return str(self.feature_name)
 
     # TODO: Decommission and find a generic way

--- a/uptrain/core/classes/measurables/reccomendation_hit_rate.py
+++ b/uptrain/core/classes/measurables/reccomendation_hit_rate.py
@@ -1,14 +1,18 @@
 import numpy as np
 
+from typing import Any
+
 from uptrain.core.classes.measurables import Measurable
 
 
 class RecHitRateMeasurable(Measurable):
+    """Class that computes the recommendation hit-rate of a model's predictions."""
+
     def __init__(self, framework) -> None:
         super().__init__(framework)
 
-    def _compute(self, inputs=None, outputs=None, gts=None, extra=None) -> any:
-        acc = [1 if gt in outputs[i] else 0 for i,gt in enumerate(gts)]
+    def _compute(self, inputs=None, outputs=None, gts=None, extra=None) -> Any:
+        acc = [1 if gt in outputs[i] else 0 for i, gt in enumerate(gts)]
         return np.array(acc)
 
     def col_name(self):

--- a/uptrain/core/classes/measurables/reccomendation_hit_rate.py
+++ b/uptrain/core/classes/measurables/reccomendation_hit_rate.py
@@ -15,5 +15,5 @@ class RecHitRateMeasurable(Measurable):
         acc = [1 if gt in outputs[i] else 0 for i, gt in enumerate(gts)]
         return np.array(acc)
 
-    def col_name(self):
+    def col_name(self) -> str:
         return "Hit-Rate"

--- a/uptrain/core/classes/measurables/scalar_from_embedding.py
+++ b/uptrain/core/classes/measurables/scalar_from_embedding.py
@@ -5,6 +5,8 @@ from uptrain.core.classes.measurables import (
 
 
 class ScalarFromEmbeddingMeasurable(Measurable):
+    """Class that extracts a scalar from a measurable embedding."""
+
     def __init__(self, framework, idx, extract_from_args) -> None:
         super().__init__(framework)
         self.idx = idx
@@ -18,12 +20,7 @@ class ScalarFromEmbeddingMeasurable(Measurable):
         )[self.idx]
 
     def col_name(self):
-        return (
-            "Scalar [Index:"
-            + str(self.idx)
-            + "] from Embedding: "
-            + str(self.extract_from.col_name())
-        )
+        return f"Scalar [Index: {str(self.idx)}] from Embedding: {str(self.extract_from.col_name())}"
 
     # TODO: Decommission and find a generic way
     def extract_val_from_training_data(self, x):

--- a/uptrain/core/classes/measurables/scalar_from_embedding.py
+++ b/uptrain/core/classes/measurables/scalar_from_embedding.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from uptrain.core.classes.measurables import (
     Measurable,
     InputFeatureMeasurable,
@@ -14,12 +16,12 @@ class ScalarFromEmbeddingMeasurable(Measurable):
             framework, extract_from_args["feature_name"]
         )
 
-    def _compute(self, inputs=None, outputs=None, gts=None, extra=None) -> any:
+    def _compute(self, inputs=None, outputs=None, gts=None, extra=None) -> Any:
         return self.extract_from._compute(
             inputs=inputs, outputs=outputs, gts=gts, extra=extra
         )[self.idx]
 
-    def col_name(self):
+    def col_name(self) -> str:
         return f"Scalar [Index: {str(self.idx)}] from Embedding: {str(self.extract_from.col_name())}"
 
     # TODO: Decommission and find a generic way


### PR DESCRIPTION
This PR adds some documentation and type hints to the files in `uptrain/core/classes/measurables`. Hopefully, it will make it easier for new contributors to understand what the code does.