### PR TITLE
Add weightwatcher to dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(
         "scikit_learn>=1.0.0",
         "streamlit>=1.0.0",
         "json-fix>=0.5.0",
+        "weightwatcher>=0.7"
     ],
     tests_require=["pytest>=7.0", "torch", "imgaug", "gensim", "xgboost", "gensim"],
 )


### PR DESCRIPTION
`uptrain/core/classes/finetuning/finetuning.py` requires the `weightwatcher` package but setup.py does not contain it as a dependency, which causes my uptrain installation to break. This PR adds weightwatcher to the dependencies.