### PR TITLE
Make weightwatcher dependency optional and improve error handling for UMAP and SHAP

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,5 +50,5 @@ setup(
         "streamlit>=1.0.0",
         "json-fix>=0.5.0"
     ],
-    tests_require=["pytest>=7.0", "torch", "imgaug", "gensim", "xgboost", "gensim"],
+    tests_require=["pytest>=7.0", "torch", "imgaug", "gensim", "xgboost"]
 )

--- a/setup.py
+++ b/setup.py
@@ -48,8 +48,7 @@ setup(
         "river<=0.14",
         "scikit_learn>=1.0.0",
         "streamlit>=1.0.0",
-        "json-fix>=0.5.0",
-        "weightwatcher>=0.7"
+        "json-fix>=0.5.0"
     ],
     tests_require=["pytest>=7.0", "torch", "imgaug", "gensim", "xgboost", "gensim"],
 )

--- a/uptrain/core/classes/finetuning/__init__.py
+++ b/uptrain/core/classes/finetuning/__init__.py
@@ -1,1 +1,1 @@
-from .finetuning import Finetune
+from .finetuning import Finetune, WEIGHTWATCHER_PRESENT

--- a/uptrain/core/classes/finetuning/finetuning.py
+++ b/uptrain/core/classes/finetuning/finetuning.py
@@ -1,4 +1,9 @@
-import weightwatcher as ww
+try:
+    import weightwatcher as ww
+    WEIGHTWATCHER_PRESENT = True
+except:
+    WEIGHTWATCHER_PRESENT = False
+
 from uptrain.core.classes.monitors import AbstractCheck
 import torch
 
@@ -42,6 +47,9 @@ class Finetune(AbstractCheck):
         device = self.device
         num_all_points = 0
         num_all_val_points = 0
+
+        if not WEIGHTWATCHER_PRESENT:
+            raise Exception("WeightWatcher is not installed. Please install it using 'pip install weightwatcher'")
         for epoch in range(self.epochs):
             # import pdb; pdb.set_trace()
             tr_loss = 0
@@ -112,3 +120,4 @@ class Finetune(AbstractCheck):
                     num_all_points,
                     self.dashboard_name,
                 )
+                

--- a/uptrain/core/classes/managers/check_manager.py
+++ b/uptrain/core/classes/managers/check_manager.py
@@ -96,7 +96,7 @@ class CheckManager:
                 custom_monitor = DimensionalityReduction(self.fw, check)
                 self.visuals_to_check.append(custom_monitor)
             else:
-                print(
+                raise Exception(
                     """UMAP is not installed. For UMAP visualization, please install umap by running `pip install umap-learn`."""
                 )
         elif check["type"] == Visual.TSNE:
@@ -107,7 +107,7 @@ class CheckManager:
                 custom_monitor = Shap(self.fw, check)
                 self.visuals_to_check.append(custom_monitor)
             else:
-                print(
+                raise Exception(
                     """SHAP is not installed. For SHAP explainability, please install it by running `pip install shap matplotlib`."""
                 )
         elif check["type"] == Visual.PLOT:


### PR DESCRIPTION
*Make weightwatcher dependency optional
*UMAP and SHAP: raise exception instead of print statement when dependency is not present