### PR TITLE
This contains the docs strings for certain classes

### DIFF
--- a/uptrain/operators/language/critique.py
+++ b/uptrain/operators/language/critique.py
@@ -27,6 +27,10 @@ class LanguageCritique(ColumnOp):
 
     Attributes:
         col_response (str): The name of the input column containing response text
+    
+    Raises :
+        Exception :  Raises exception for any failed evaluation attempts
+    
     """
 
     col_response: str = "response"
@@ -61,6 +65,10 @@ class ToneCritique(ColumnOp):
     Attributes:
         persona (str): The persona the chatbot being assesses was expected to follow
         col_response (str): The name of the input column containing response text
+    
+    Raise:
+        Exception : Raises exception for any failed evaluation attempts
+    
     """
 
     persona: str = "helpful-chatbot"

--- a/uptrain/operators/language/critique.py
+++ b/uptrain/operators/language/critique.py
@@ -29,7 +29,7 @@ class LanguageCritique(ColumnOp):
         col_response (str): The name of the input column containing response text
     
     Raises:
-        Exception:  Raises exception for any failed evaluation attempts
+        Exception: Raises exception for any failed evaluation attempts
     
     """
 

--- a/uptrain/operators/language/critique.py
+++ b/uptrain/operators/language/critique.py
@@ -28,8 +28,8 @@ class LanguageCritique(ColumnOp):
     Attributes:
         col_response (str): The name of the input column containing response text
     
-    Raises :
-        Exception :  Raises exception for any failed evaluation attempts
+    Raises:
+        Exception:  Raises exception for any failed evaluation attempts
     
     """
 
@@ -66,8 +66,8 @@ class ToneCritique(ColumnOp):
         persona (str): The persona the chatbot being assesses was expected to follow
         col_response (str): The name of the input column containing response text
     
-    Raise:
-        Exception : Raises exception for any failed evaluation attempts
+    Raises:
+        Exception: Raises exception for any failed evaluation attempts
     
     """
 

--- a/uptrain/operators/language/text.py
+++ b/uptrain/operators/language/text.py
@@ -266,6 +266,17 @@ class TextComparison(ColumnOp):
 # Check if a Keyword exists in input text
 @register_op
 class KeywordDetector(ColumnOp):
+    """
+    Detect keywords in given text.
+    
+    Attributes:
+        col_in_text: (str) The input text.
+        keyword: (str) The keywords to be checked.
+        col_out: str = "keyword_detector"
+
+
+    
+    """
     col_in_text: str
     keyword: str
     col_out: str = "keyword_detector"

--- a/uptrain/operators/language/with_context.py
+++ b/uptrain/operators/language/with_context.py
@@ -24,8 +24,8 @@ class ResponseFactualScore(ColumnOp):
         col_context: (str) Coloumn name for stored context 
         col_response (str): Coloumn name for the stored responses
     
-    Raises :
-        Exception : Raises exception for any failed evaluation attempts
+    Raises:
+        Exception: Raises exception for any failed evaluation attempts
     
    
    
@@ -70,8 +70,8 @@ class ResponseCompleteness(ColumnOp):
         col_question (str): Column name for the stored questions
         col_response (str): Coloumn name for the stored responses
     
-    Raises :
-        Exception :  Raises exception for any failed evaluation attempts   
+    Raises:
+        Exception: Raises exception for any failed evaluation attempts   
         
     """
 
@@ -110,12 +110,12 @@ class ContextRelevance(ColumnOp):
     """
     Grade how relevant the context was to the question asked.
     
-    Attributes : 
+    Attributes: 
         col_question: (str) Column Name for the stored questions
         col_context: (str) Coloumn name for stored context 
     
-    Raises :
-        Exception :  Raises exception for any failed evaluation attempts
+    Raises:
+        Exception:  Raises exception for any failed evaluation attempts
 
     """
 
@@ -156,8 +156,8 @@ class ResponseRelevance(ColumnOp):
         col_question (str): Column name for the stored questions
         col_response (str): Coloumn name for the stored responses
     
-    Raises :
-        Exception :  Raises exception for any failed evaluation attempts 
+    Raises:
+        Exception: Raises exception for any failed evaluation attempts 
     
     
     """

--- a/uptrain/operators/language/with_context.py
+++ b/uptrain/operators/language/with_context.py
@@ -18,6 +18,17 @@ from uptrain.operators.base import *
 class ResponseFactualScore(ColumnOp):
     """
     Grade how factual the generated response was.
+    
+     Attributes:
+        col_question (str): Column name for the stored questions
+        col_context: (str) Coloumn name for stored context 
+        col_response (str): Coloumn name for the stored responses
+    
+    Raises :
+        Exception : Raises exception for any failed evaluation attempts
+    
+   
+   
     """
 
     col_question: str = "question"
@@ -54,6 +65,14 @@ class ResponseFactualScore(ColumnOp):
 class ResponseCompleteness(ColumnOp):
     """
     Grade how complete the generated response was for the question specified.
+    
+    Attributes:
+        col_question (str): Column name for the stored questions
+        col_response (str): Coloumn name for the stored responses
+    
+    Raises :
+        Exception :  Raises exception for any failed evaluation attempts   
+        
     """
 
     col_question: str = "question"
@@ -90,6 +109,14 @@ class ResponseCompleteness(ColumnOp):
 class ContextRelevance(ColumnOp):
     """
     Grade how relevant the context was to the question asked.
+    
+    Attributes : 
+        col_question: (str) Column Name for the stored questions
+        col_context: (str) Coloumn name for stored context 
+    
+    Raises :
+        Exception :  Raises exception for any failed evaluation attempts
+
     """
 
     col_question: str = "question"
@@ -124,6 +151,15 @@ class ContextRelevance(ColumnOp):
 class ResponseRelevance(ColumnOp):
     """
     Grade how if the generated response has any additional irrelevant information for the question asked.
+    
+    Attributes:
+        col_question (str): Column name for the stored questions
+        col_response (str): Coloumn name for the stored responses
+    
+    Raises :
+        Exception :  Raises exception for any failed evaluation attempts 
+    
+    
     """
 
     col_question: str = "question"

--- a/uptrain/operators/language/with_context.py
+++ b/uptrain/operators/language/with_context.py
@@ -115,7 +115,7 @@ class ContextRelevance(ColumnOp):
         col_context: (str) Coloumn name for stored context 
     
     Raises:
-        Exception:  Raises exception for any failed evaluation attempts
+        Exception: Raises exception for any failed evaluation attempts
 
     """
 

--- a/uptrain/operators/table.py
+++ b/uptrain/operators/table.py
@@ -25,8 +25,7 @@ class Table(OpBaseModel):
     Attributes:
         props (dict): Additional properties to pass to the Table constructor.
         title (str): The title of the chart.
-        Kind (str) : to depict what type of output
-    
+
     """
 
     props: dict = Field(default_factory=dict)

--- a/uptrain/operators/table.py
+++ b/uptrain/operators/table.py
@@ -25,7 +25,8 @@ class Table(OpBaseModel):
     Attributes:
         props (dict): Additional properties to pass to the Table constructor.
         title (str): The title of the chart.
-
+        Kind (str) : to depict what type of output
+    
     """
 
     props: dict = Field(default_factory=dict)


### PR DESCRIPTION
###Problem Addressed

Certain classes in the operator section had missing documentation. 
(Operators.Table , operators.Context_Relevance , operators.KeywordDetector , operators.outputparser ,operators.LanguageCritique , ResponseCompleteness, ResponseRelevance, ToneCritique, WordCount)


### Description

These classes where in the files critique.py , table.py , text.py and with_context.py in the operators folder.

The missing documentation has been filled in for these classes.


### Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/uptrain-ai/uptrain/blob/main/CONTRIBUTING.md) document.
- [ ] My code follows the code style (BLACK) of this project.
- [ ] I have updated the documentation accordingly.


