### PR TITLE
Update openai dependency

### DIFF
--- a/uptrain/cli.py
+++ b/uptrain/cli.py
@@ -35,7 +35,7 @@ EXTRA_PACKAGES = {
         "rouge-score",
         # "sentence-transformers",
         # "InstructorEmbedding",
-        "openai>=0.27",
+        "openai<=0.28",
         "evals @ git+https://github.com/openai/evals.git",
         "replicate"
     ],
@@ -52,7 +52,7 @@ EXTRA_PACKAGES = {
         "rouge-score",
         "sentence-transformers",
         "InstructorEmbedding",
-        "openai>=0.27",
+        "openai<=0.28",
         "evals @ git+https://github.com/openai/evals.git",
         "replicate"
     ],

--- a/uptrain/cli.py
+++ b/uptrain/cli.py
@@ -35,7 +35,7 @@ EXTRA_PACKAGES = {
         "rouge-score",
         # "sentence-transformers",
         # "InstructorEmbedding",
-        "openai<=0.28",
+        "openai==0.28",
         "evals @ git+https://github.com/openai/evals.git",
         "replicate"
     ],
@@ -52,7 +52,7 @@ EXTRA_PACKAGES = {
         "rouge-score",
         "sentence-transformers",
         "InstructorEmbedding",
-        "openai<=0.28",
+        "openai==0.28",
         "evals @ git+https://github.com/openai/evals.git",
         "replicate"
     ],


### PR DESCRIPTION
Latest version is not supported by our code. Will revert to older version for now and refactor after testing. 

```
deployment-worker-1     | You tried to access openai.ChatCompletion, but this is no longer supported in openai>=1.0.0 - see the README at https://github.com/openai/openai-python for the API.
deployment-worker-1     |
deployment-worker-1     | You can run `openai migrate` to automatically upgrade your codebase to use the 1.0.0 interface.
deployment-worker-1     |
deployment-worker-1     | Alternatively, you can pin your installation to the old version, e.g. `pip install openai==0.28`
deployment-worker-1     |
deployment-worker-1     | A detailed migration guide is available here: https://github.com/openai/openai-python/discussions/742
```