### PR TITLE
Disable Next.js telemetry in compose by default

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,8 @@ services:
     restart: always
     entrypoint: ["npm", "run", "dev"]
     working_dir: "/app/"
+    environment:
+      - NEXT_TELEMETRY_DISABLED=1
     ports:
       - 3000:3000
     profiles: ["server"]


### PR DESCRIPTION
## Pull Request Template

### Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Description

Please include a summary of the change and which issue it addresses. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

### Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/uptrain-ai/uptrain/blob/main/CONTRIBUTING.md) document.
- [ ] My code follows the code style (BLACK) of this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation accordingly.
- [ ] I have added an appropriate CHANGELOG entry.

### Author's Note

This PR *does not touch any code* - it just disables the newly built-in Next.js telemetry in the `docker-compose.yml` by setting the env. I verified via `bash run_uptrain.sh` that telemetry is off. 

The reasoning behind this change is to avoid unnecessary traffic and work for network or security teams.

Before:
![Screenshot from 2024-03-06 16-28-07](https://github.com/uptrain-ai/uptrain/assets/129862349/58c153ae-38f2-43cd-ba21-0e4f6746fbf7)

After:
![Screenshot from 2024-03-06 16-28-26](https://github.com/uptrain-ai/uptrain/assets/129862349/6822aa73-047b-4430-bad4-15203a195e24)
