### PR TITLE
docs: refactor getting-started.mdx steps for UpTrain dashboard

### DIFF
--- a/docs/getting-started/dashboard/getting_started.mdx
+++ b/docs/getting-started/dashboard/getting_started.mdx
@@ -12,18 +12,27 @@ You can use the dashboard to evaluate your LLM applications, view the results, m
 
 <Note>Before you start, ensure you have docker installed on your machine. If not, you can install it from [here](https://docs.docker.com/get-docker/). </Note>
 
-
-### How to install?
-
-The following commands will download the UpTrain dashboard and start it on your local machine:
-```bash
-# Clone the repository
-git clone https://github.com/uptrain-ai/uptrain
-cd uptrain
-
-# Run UpTrain
-bash run_uptrain.sh
-```
+<Steps>
+  <Step title="How to install?">
+    Open your terminal and run the following commands to clone the UpTrain GitHub repository and navigate to the project directory:
+    ```bash
+    git clone https://github.com/uptrain-ai/uptrain
+    cd uptrain
+    ```
+  </Step>
+  <Step title="Run the UpTrain Bash Script">
+    Execute the following command to start the UpTrain dashboard:
+    ```bash
+    bash run_uptrain.sh
+    ```
+  </Step>
+  <Step title="Access the Dashboard">
+    Once the script is running, open your web browser and go to:
+    ```
+    http://localhost:3000
+    ```
+  </Step>
+</Steps>
 
 <Note>UpTrain Dashboard is currently in Beta version. We would love your feedback to improve it.</Note>
 


### PR DESCRIPTION
added installation instructions using <Steps> and <Step> tags, including commands for accessing the uptrain dashboard on localhost.