### PR TITLE
docs: fix image paths to include `/docs` directory

### DIFF
--- a/docs/getting-started/dashboard/evaluations.mdx
+++ b/docs/getting-started/dashboard/evaluations.mdx
@@ -19,12 +19,12 @@ You can look at the complete list of UpTrain's supported metrics [here](/predefi
   <Step title = "Create a new Project">
     Click on `Create New Project` from Home
     <Frame>
-      <img src="/assets/dashboard/dashboard_home.png" />
+      <img src="/docs/assets/dashboard/dashboard_home.png" />
     </Frame>
   </Step>
   <Step title = "Enter Project Information">
     <Frame>
-      <img src="/assets/dashboard/dashboard_project.png" />
+      <img src="/docs/assets/dashboard/dashboard_project.png" />
     </Frame>
     * `Project name:` Create a name for your project
     * `Dataset name:` Create a name for your dataset
@@ -40,18 +40,18 @@ You can look at the complete list of UpTrain's supported metrics [here](/predefi
   </Step>
   <Step title = "Select Evaluations to Run">
     <Frame>
-      <img src="/assets/dashboard/eval_select_metrics.png" />
+      <img src="/docs/assets/dashboard/eval_select_metrics.png" />
     </Frame>
   </Step>
   <Step title = "View Evaluations">
     You can see all the evaluations ran using UpTrain
     <Frame>
-      <img src="/assets/dashboard/eval.png" />
+      <img src="/docs/assets/dashboard/eval.png" />
     </Frame>
 
     You can also see individual logs
     <Frame>
-      <img src="/assets/dashboard/eval_logs.png" />
+      <img src="/docs/assets/dashboard/eval_logs.png" />
     </Frame>
   </Step>
 </Steps>

--- a/docs/getting-started/dashboard/experiments.mdx
+++ b/docs/getting-started/dashboard/experiments.mdx
@@ -19,12 +19,12 @@ You can look at the complete list of UpTrain's supported metrics [here](/predefi
   <Step title = "Create a new Project">
     Click on `Create New Project` from Home
     <Frame>
-      <img src="/assets/dashboard/dashboard_home.png" />
+      <img src="/docs/assets/dashboard/dashboard_home.png" />
     </Frame>
   </Step>
   <Step title = "Enter Project Information">
     <Frame>
-      <img src="/assets/dashboard/dashboard_experiment.png" />
+      <img src="/docs/assets/dashboard/dashboard_experiment.png" />
     </Frame>
     * `Project name:` Create a name for your project
     * `Dataset name:` Create a name for your dataset
@@ -41,18 +41,18 @@ You can look at the complete list of UpTrain's supported metrics [here](/predefi
   </Step>
   <Step title = "Select Evaluations to Run">
     <Frame>
-      <img src="/assets/dashboard/eval_select_metrics.png" />
+      <img src="/docs/assets/dashboard/eval_select_metrics.png" />
     </Frame>
   </Step>
   <Step title = "View Experiments">
     You can see all the evaluations ran using UpTrain
     <Frame>
-      <img src="/assets/dashboard/exp.png" />
+      <img src="/docs/assets/dashboard/exp.png" />
     </Frame>
 
     You can also see individual logs
     <Frame>
-      <img src="/assets/dashboard/exp_logs.png" />
+      <img src="/docs/assets/dashboard/exp_logs.png" />
     </Frame>
   </Step>
 </Steps>

--- a/docs/getting-started/dashboard/project.mdx
+++ b/docs/getting-started/dashboard/project.mdx
@@ -16,7 +16,7 @@ There are 2 types of projects we support:
   <Step title = "Create a new Project">
     Click on `Create New Project` from Home
     <Frame>
-      <img src="/assets/dashboard/dashboard_home.png" />
+      <img src="/docs/assets/dashboard/dashboard_home.png" />
     </Frame>
   </Step>
   <Step title = "Enter Project Information">
@@ -31,7 +31,7 @@ There are 2 types of projects we support:
       ```
     * `Evaluation LLM:` Select an LLM to run evaluations
     <Frame>
-      <img src="/assets/dashboard/dashboard_project1.png" />
+      <img src="/docs/assets/dashboard/dashboard_project.png" />
     </Frame>
   </Step>
 </Steps>


### PR DESCRIPTION
fixed all asset paths by adding '/docs' as a prefix to ensure correct referencing.