### PR TITLE
docs: fix typos by replacing 'reponse' with 'response' in docs and notebooks

### DIFF
--- a/docs/integrations/observation-tools/helicone.mdx
+++ b/docs/integrations/observation-tools/helicone.mdx
@@ -108,7 +108,7 @@ We will walk you through the use of Helicone for monitoring and log your UpTrain
 
     2. [Factual Accuracy](https://docs.uptrain.ai/predefined-evaluations/context-awareness/factual-accuracy): Evaluates whether the response generated is factually correct and grounded by the provided context.
 
-    3. [Context Utilization](https://docs.uptrain.ai/predefined-evaluations/context-awareness/context-utilization): Evaluates how complete the generated response is for the question specified given the information provided in the context. Also known as Reponse Completeness wrt context
+    3. [Context Utilization](https://docs.uptrain.ai/predefined-evaluations/context-awareness/context-utilization): Evaluates how complete the generated response is for the question specified given the information provided in the context. Also known as Response Completeness wrt context
 
     4. [Response Relevance](https://docs.uptrain.ai/predefined-evaluations/response-quality/response-relevance): Evaluates how relevant the generated response was to the question specified.
 

--- a/docs/llms/ollama.mdx
+++ b/docs/llms/ollama.mdx
@@ -101,7 +101,7 @@ results = eval_llm.evaluate(
     checks=[Evals.CONTEXT_RELEVANCE, Evals.RESPONSE_CONCISENESS, Evals.RESPONSE_RELEVANCE]
 )
 ```
-Sample Reponse:
+Sample Response:
 ```json
 [  
   {  'context': 'France, context for its exquisite pastries and fashion, has '

--- a/docs/predefined-evaluations/custom-evals/custom-guideline.mdx
+++ b/docs/predefined-evaluations/custom-evals/custom-guideline.mdx
@@ -52,7 +52,7 @@ Sample Response:
 ```
 <Note>A higher guideline adherence score reflects that the generated response contains adheres to defined guideline.</Note>
 
-The generated reponse contains numeric information about the height of Burj Khalifa, which conflicts the defined guideline.
+The generated response contains numeric information about the height of Burj Khalifa, which conflicts the defined guideline.
 
 Resulting in a low guideline adherence score.
 

--- a/docs/predefined-evaluations/language-quality/fluency-and-coherence.mdx
+++ b/docs/predefined-evaluations/language-quality/fluency-and-coherence.mdx
@@ -45,7 +45,7 @@ Sample Response:
 ```
 <Note>Higher language features scores reflects a good response.</Note>
 
-The reponse generated does not seem good, it has innapropriate words like "dummy", there are some grammatical errors and uses unnecessary slangs like: "I will guide you", "it is pretty straightforward"
+The response generated does not seem good, it has innapropriate words like "dummy", there are some grammatical errors and uses unnecessary slangs like: "I will guide you", "it is pretty straightforward"
 
 Resulting in low language feature scores.
 

--- a/docs/predefined-evaluations/overview.mdx
+++ b/docs/predefined-evaluations/overview.mdx
@@ -25,11 +25,11 @@ You can choose evals as per your needs. We have divided them into a few categori
   <Accordion title="Response Quality Evals">
 | Eval | Description |
 | ---- | ----------- |
-|[Reponse Completeness](/predefined-evaluations/response-quality/response-completeness) | Grades whether the response has answered all the aspects of the question specified. |
-|[Reponse Conciseness](/predefined-evaluations/response-quality/response-conciseness) | Grades how concise the generated response is or if it has any additional irrelevant information for the question asked. |
-|[Reponse Relevance](/predefined-evaluations/response-quality/response-relevance)| Grades how relevant the generated context was to the question specified.|
-|[Reponse Validity](/predefined-evaluations/response-quality/response-validity)| Grades if the response generated is valid or not. A response is considered to be valid if it contains any information.|
-|[Reponse Consistency](/predefined-evaluations/response-quality/response-consistency)| Grades how consistent the response is with the question asked as well as with the context provided.|
+|[Response Completeness](/predefined-evaluations/response-quality/response-completeness) | Grades whether the response has answered all the aspects of the question specified. |
+|[Response Conciseness](/predefined-evaluations/response-quality/response-conciseness) | Grades how concise the generated response is or if it has any additional irrelevant information for the question asked. |
+|[Response Relevance](/predefined-evaluations/response-quality/response-relevance)| Grades how relevant the generated context was to the question specified.|
+|[Response Validity](/predefined-evaluations/response-quality/response-validity)| Grades if the response generated is valid or not. A response is considered to be valid if it contains any information.|
+|[Response Consistency](/predefined-evaluations/response-quality/response-consistency)| Grades how consistent the response is with the question asked as well as with the context provided.|
   </Accordion>
 
   <Accordion title="Context Awareness Evals">

--- a/examples/experiments/llm_openai_vs_claude_experiment.ipynb
+++ b/examples/experiments/llm_openai_vs_claude_experiment.ipynb
@@ -43,7 +43,7 @@
     "\n",
     "3. [Factual Accuracy](https://docs.uptrain.ai/predefined-evaluations/context-awareness/factual-accuracy): Evaluates whether the response generated is factually correct and grounded by the provided context.\n",
     "\n",
-    "4. [Context Utilization](https://docs.uptrain.ai/predefined-evaluations/context-awareness/context-utilization): Evaluates how complete the generated response is for the question specified given the information provided in the context. Also known as Reponse Completeness wrt context\n",
+    "4. [Context Utilization](https://docs.uptrain.ai/predefined-evaluations/context-awareness/context-utilization): Evaluates how complete the generated response is for the question specified given the information provided in the context. Also known as Response Completeness wrt context\n",
     "\n",
     "5. [Response Relevance](https://docs.uptrain.ai/predefined-evaluations/response-quality/response-relevance): Evaluates how relevant the generated response was to the question specified.\n",
     "\n",

--- a/examples/experiments/llm_openai_vs_gemma7b_experiment.ipynb
+++ b/examples/experiments/llm_openai_vs_gemma7b_experiment.ipynb
@@ -43,7 +43,7 @@
     "\n",
     "3. [Factual Accuracy](https://docs.uptrain.ai/predefined-evaluations/context-awareness/factual-accuracy): Evaluates whether the response generated is factually correct and grounded by the provided context.\n",
     "\n",
-    "4. [Context Utilization](https://docs.uptrain.ai/predefined-evaluations/context-awareness/context-utilization): Evaluates how complete the generated response is for the question specified given the information provided in the context. Also known as Reponse Completeness wrt context\n",
+    "4. [Context Utilization](https://docs.uptrain.ai/predefined-evaluations/context-awareness/context-utilization): Evaluates how complete the generated response is for the question specified given the information provided in the context. Also known as Response Completeness wrt context\n",
     "\n",
     "5. [Response Relevance](https://docs.uptrain.ai/predefined-evaluations/response-quality/response-relevance): Evaluates how relevant the generated response was to the question specified.\n",
     "\n",

--- a/examples/integrations/observation_tools/helicone.ipynb
+++ b/examples/integrations/observation_tools/helicone.ipynb
@@ -236,7 +236,7 @@
         "\n",
         "2. [Factual Accuracy](https://docs.uptrain.ai/predefined-evaluations/context-awareness/factual-accuracy): Evaluates whether the response generated is factually correct and grounded by the provided context.\n",
         "\n",
-        "3. [Context Utilization](https://docs.uptrain.ai/predefined-evaluations/context-awareness/context-utilization): Evaluates how complete the generated response is for the question specified given the information provided in the context. Also known as Reponse Completeness wrt context\n",
+        "3. [Context Utilization](https://docs.uptrain.ai/predefined-evaluations/context-awareness/context-utilization): Evaluates how complete the generated response is for the question specified given the information provided in the context. Also known as Response Completeness wrt context\n",
         "\n",
         "4. [Response Relevance](https://docs.uptrain.ai/predefined-evaluations/response-quality/response-relevance): Evaluates how relevant the generated response was to the question specified.\n",
         "\n",


### PR DESCRIPTION
### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### Description

This PR fixes a typo in the documentation and notebooks where the word "reponse" was incorrectly used instead of "response." This change ensures consistency and clarity across the project's documentation.

Fixes # (N/A)

### Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/uptrain-ai/uptrain/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style (BLACK) of this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have updated the documentation accordingly.
- [ ] I have added an appropriate CHANGELOG entry.

### Author's Note

Please let me know if there are any additional areas that need review or further clarification.
