### PR TITLE
fix: dashboard errors and ARM64 support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: "3.9"
 services:
   ### FastAPI server
   server:
+    platform: linux/arm64
     build: ./uptrain/dashboard/backend
     image: ghcr.io/uptrain-ai/uptrain:v0.1
     restart: always
@@ -17,6 +18,7 @@ services:
 
   ###  dashboard
   dashboard:
+    platform: linux/arm64
     build: ./uptrain/dashboard/frontend
     image: ghcr.io/uptrain-ai/uptrain-dashboard:v0.1
     restart: always

--- a/uptrain/dashboard/frontend/dashboard/src/components/Evaluations/Homepage/AddProjectModal/AddProjectModal.js
+++ b/uptrain/dashboard/frontend/dashboard/src/components/Evaluations/Homepage/AddProjectModal/AddProjectModal.js
@@ -100,17 +100,19 @@ const AddProjectModal = (props) => {
     const multiChecks = [];
     const data = {};
 
-    for (let i = 0; i < props.checks.checks.length; i++) {
-      const item = props.checks.checks[i];
-      if (singleMetrics.includes(item.check_name)) {
-        singleChecks.push(singleMetrics.indexOf(item.check_name));
-      } else if (multiMetrics.hasOwnProperty(item.check_name)) {
-        multiChecks.push(item.check_name);
-        data[item.check_name] = {};
+    if (props.checks && props.checks.checks) {
+      for (let i = 0; i < props.checks.checks.length; i++) {
+        const item = props.checks.checks[i];
+        if (singleMetrics.includes(item.check_name)) {
+          singleChecks.push(singleMetrics.indexOf(item.check_name));
+        } else if (multiMetrics.hasOwnProperty(item.check_name)) {
+          multiChecks.push(item.check_name);
+          data[item.check_name] = {};
 
-        for (const key in item) {
-          if (key === "check_name") continue;
-          data[item.check_name][key] = item[key];
+          for (const key in item) {
+            if (key === "check_name") continue;
+            data[item.check_name][key] = item[key];
+          }
         }
       }
     }

--- a/uptrain/dashboard/frontend/dashboard/src/store/reducers/userInfo.js
+++ b/uptrain/dashboard/frontend/dashboard/src/store/reducers/userInfo.js
@@ -26,7 +26,7 @@ const userInfoSlice = createSlice({
   },
 });
 
-export const { addUserData } = userInfoSlice.actions;
+export const { addUserData, removeUserData } = userInfoSlice.actions;
 export default userInfoSlice.reducer;
 export const selectUserName = (state) => state.userInfo.user_name;
 export const selectTotalCredits = (state) => state.userInfo.credits_total;


### PR DESCRIPTION
This PR includes several fixes:

1. Added null checks in AddProjectModal to prevent errors when accessing props.checks
2. Exported removeUserData action from userInfo reducer
3. Added ARM64 platform support in docker-compose for M1/M2 Mac compatibility

Changes made:
- Added null check before accessing props.checks.checks in AddProjectModal
- Added removeUserData to exported actions in userInfo reducer
- Added platform: linux/arm64 to both services in docker-compose.yml

These changes improve stability on M1/M2 Macs and prevent runtime errors in the dashboard.
